### PR TITLE
Added RegistryKeyNotFoundException

### DIFF
--- a/shellbags.py
+++ b/shellbags.py
@@ -1091,7 +1091,13 @@ def get_shellbags(shell_key):
                             })
                         offset += size
         except Registry.RegistryValueNotFoundException:
+            debug("Registry.RegistryValueNotFoundException")
             pass
+        except Registry.RegistryKeyNotFoundException:
+            debug("Registry.RegistryKeyNotFoundException")
+            pass
+        except:
+            debug("Unexpected error %s" % sys.exc_info()[0])
 
         # Next, recurse into each BagMRU key
         for value in [value for value in key.values() \


### PR DESCRIPTION
Based off some testing, I identified a condition where RegistryKeyNotFoundException was being thrown and not caught, resulting in the script under-reporting on shellbags.

I've also added a general "except" statement that will identify other uncaught exceptions in the future. 
