### PR TITLE
add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+#! /usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='shellbags',
+    author='Willi Ballenthin',
+    version='0.5',
+    install_requires=[
+        'python-registry',
+    ],
+    py_modules=[
+        'BinaryParser',
+        'ShellItems',
+    ],
+    scripts=[
+        'shellbags.py',
+    ],
+)


### PR DESCRIPTION
Hello Willi!

Being able to `pip install https://github.com/williballenthin/shellbags/archive/$SHA1.zip` is really convenient, especially in a Dockerfile (like the one [I started](https://github.com/nbareil/docker-forensics/blob/master/Dockerfile)). So here is a `setup.py` :)

Best regards